### PR TITLE
Fix contrast error in Note callout text

### DIFF
--- a/src/lib/components/Note.svelte
+++ b/src/lib/components/Note.svelte
@@ -36,6 +36,7 @@
 		white-space: pre;
 		display: flex;
 		align-items: center;
+		color: var(--darkGray);
 	}
 
 	.note__callout-arrow {


### PR DESCRIPTION
`<Note>` callout text (not the note content) [fails accessibility contrast](https://webaim.org/resources/contrastchecker/?fcolor=CFCFCF&bcolor=FFD000) on dark mode.

## Light Mode

_(No issue here, simply here to compare.)_

![light mode example](https://github.com/josh-collinsworth/joco-sveltekit/assets/20092441/fa63fb0a-f56f-4b0b-ae47-51d00fd06f61)

## Dark Mode

### Before

![dark mode example before fix](https://github.com/josh-collinsworth/joco-sveltekit/assets/20092441/b3b7cf8c-3574-4de6-a6e8-6f5cb5afcd0b)

### After

![dark mode example after fix](https://github.com/josh-collinsworth/joco-sveltekit/assets/20092441/eac5b5ab-8f30-4ec3-ac29-ee9388e32078)
